### PR TITLE
Set up ui dev server and wire it up correctly

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,9 @@ services:
       dockerfile: Dockerfile
     ports:
       - '8082:3000'
+    volumes:
+      - './packages/ui/csc-ui:/app'
+      - '/app/node_modules'
 
   csc-reverse-proxy:
     container_name: csc-reverse-proxy

--- a/packages/ui/Dockerfile
+++ b/packages/ui/Dockerfile
@@ -2,11 +2,9 @@ FROM node:18-alpine
 
 WORKDIR /app
 
-COPY csc-ui ./
+COPY csc-ui/package.json /app/package.json
 RUN yarn install
 
 EXPOSE 3000
 
-RUN yarn build
-
-ENTRYPOINT ["yarn", "preview"]
+ENTRYPOINT ["yarn", "dev"]

--- a/packages/ui/csc-ui/package.json
+++ b/packages/ui/csc-ui/package.json
@@ -2,7 +2,7 @@
   "name": "csc-ui",
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview --port 3000 --host"
   },

--- a/packages/ui/csc-ui/src/App.vue
+++ b/packages/ui/csc-ui/src/App.vue
@@ -48,7 +48,7 @@
         submit() {
             console.log(JSON.stringify(this.featuresAsGeoJson));
             this.axios
-              .post("http://localhost:80/summarize", this.featuresAsGeoJson)
+              .post("/api/completeness", this.featuresAsGeoJson)
               .then((response) => {
                 console.log(response.data)
               });

--- a/packages/ui/csc-ui/vite.config.js
+++ b/packages/ui/csc-ui/vite.config.js
@@ -34,5 +34,13 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://csc-server',
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/api/, '')
+      }
+    }
   },
 })


### PR DESCRIPTION
- Add volume config in docker-compose, so the container works for development (the container sees changed files and can rebuild on save)
- Use "yarn dev" which runs vite in dev mode in the ui container
- Adapt vite proxy config and request in App.vue, so front end can reach api

=> UI can now be tested with these steps:
- Run `docker compose up -d`
- Run `docker compose run csc-process update`
- Open http://localhost:8082/ in browser